### PR TITLE
fix: Depend on sdl2 and sdl2_ttf provided by system as default

### DIFF
--- a/.github/workflows/ubuntu-build.yml
+++ b/.github/workflows/ubuntu-build.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           action: build
           meson-version: 0.63.1
+          setup-options: -Duse_sdl2_subproject=true
       - name: Run tests
         run: |
           cd build

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ brew install vivictpp
 ```console
 
 $ apt-get --fix-missing install -y cmake python3-pip gcc python3-setuptools \
-  python3-wheel libsdl2-dev libsdl2-ttf-dev libfreetype6-dev libavformat-dev libavcodec-dev \
+  python3-wheel libfreetype6-dev libavformat-dev libavcodec-dev \
   libavfilter-dev libswscale-dev pkg-config
 
 ```
@@ -65,9 +65,13 @@ $ pip3 install ninja meson
 
 ```console
 
-$ meson builddir
+$ meson -Duse_sdl2_subproject=true builddir
 
 ```
+
+(Setting the `use_sdl2_subproject` option will cause meson to build sdl2 and sdl2_ttf
+as subprojects. This is recomended on ubuntu since the sdl2 version provided by ubuntu
+is not the most recent one)
 
 3. Compile
 

--- a/meson.build
+++ b/meson.build
@@ -11,12 +11,20 @@ spdlog_proj = subproject('spdlog', default_options: 'warning_level=0')
 cli11_proj = subproject('cli11', default_options: 'warning_level=0')
 catch2_proj = subproject('catch2', default_options: 'warning_level=0')
 fmt_proj = subproject('fmt', default_options: 'warning_level=0')
-sdl2_proj = subproject('sdl2', default_options: ['warning_level=0', 'test=false'])
-sdl2_ttf_proj = subproject('sdl2_ttf', default_options: 'warning_level=0')
+
+if get_option('use_sdl2_subproject')
+  sdl2_proj = subproject('sdl2', default_options: ['warning_level=0', 'test=false'])
+  sdl2_dep = sdl2_proj.get_variable('sdl2_dep')
+  sdl2_ttf_proj = subproject('sdl2_ttf', default_options: 'warning_level=0')
+  sdl2_ttf_dep = sdl2_ttf_proj.get_variable('sdl2_ttf_dep')
+else
+  sdl2_dep = dependency('sdl2', fallback: ['sdl2', 'sdl2_dep'])
+  sdl2_ttf_dep = dependency('sdl2_ttf', fallback: ['sdl2_ttf', 'sdl2_ttf_dep'])
+endif
 
 deps = [
-  sdl2_proj.get_variable('sdl2_dep'),
-  sdl2_ttf_proj.get_variable('sdl2_ttf_dep'),
+  sdl2_dep,
+  sdl2_ttf_dep,
   dependency('freetype2', version: '>=2.8.1'),
   dependency('threads'),
   dependency('libavformat'),

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('use_sdl2_subproject', type : 'boolean', value : false, description: 'Prefer sdl2 and sdl2_ttf from subprojects instead of system libraries')


### PR DESCRIPTION
As default, meson will use sdl2 and sdl2_ttf provided by system if available. If they are not provided, or if the
use_sdl2_subproject build option is true, sdl2 and sdl2_ttf will be built as subprojects. The main motivation for building them as subprojects is if the system provides an outdated version of sdl2, ie < 2.24.0.

Signed-off-by: Gustav Grusell <gustav.grusell@gmail.com>