### PR TITLE
fix: disable imgui.ini, otherwise litters CWD

### DIFF
--- a/src/imgui/ImGuiSDL.cc
+++ b/src/imgui/ImGuiSDL.cc
@@ -30,6 +30,10 @@ vivictpp::imgui::ImGuiSDL::ImGuiSDL(const UiOptions &uiOptions):
 
   ImGui::CreateContext();
 
+  ImGuiIO& io = ImGui::GetIO();
+  // disable imgui.ini (which otherwise litters the current working directory)
+  io.IniFilename = NULL;
+
   // Setup Dear ImGui style
   ImGui::StyleColorsDark();
 


### PR DESCRIPTION
I noticed that 0.3.1 creates an imgui.ini in any directory I launch vivictpp from.
It doesn't seem essential, so I've disabled it. If you prefer to keep it, perhaps it could be placed in a constant location according to XDG guidelines, instead of the current working directory.