### PR TITLE
feat: display hardware acceleration status and decoder in UI

### DIFF
--- a/include/VideoMetadata.hh
+++ b/include/VideoMetadata.hh
@@ -39,7 +39,8 @@ public:
   VideoMetadata(std::string source,
                 AVFormatContext *formatContext,
                 AVStream *videoStream,
-                FilteredVideoMetadata filteredVideoMetadata);
+                FilteredVideoMetadata filteredVideoMetadata,
+                AVCodecContext *codecContext);
 
   std::string source;
   int streamIndex;
@@ -54,6 +55,7 @@ public:
   vivictpp::time::Time duration;
   vivictpp::time::Time endTime;
   std::string codec;
+  bool hwAccel;
 
   std::string toString() const;
   bool empty() const { return _empty; }

--- a/include/VideoMetadata.hh
+++ b/include/VideoMetadata.hh
@@ -56,6 +56,7 @@ public:
   vivictpp::time::Time endTime;
   std::string codec;
   bool hwAccel;
+  std::string decoderName;
 
   std::string toString() const;
   bool empty() const { return _empty; }

--- a/src/VideoMetadata.cc
+++ b/src/VideoMetadata.cc
@@ -26,6 +26,16 @@ bool hasHwAccel(AVCodecContext *codecContext) {
   return codecContext ? codecContext->hw_device_ctx != NULL : false;
 }
 
+// TODO: Rework this to show the actual decoder
+std::string getDecoderName(AVCodecContext *codecContext) {
+    if (hasHwAccel(codecContext)) {
+      AVHWDeviceContext *deviceContext = (AVHWDeviceContext*) codecContext->hw_device_ctx->data;
+      return av_hwdevice_get_type_name(deviceContext->type);
+    } else {
+      return "software";
+    }
+}
+
 vivictpp::time::Time getStartTime(AVStream *stream) {
   return stream->start_time == AV_NOPTS_VALUE ? 0 :
     av_rescale_q(stream->start_time, stream->time_base, vivictpp::time::TIME_BASE_Q);
@@ -57,6 +67,7 @@ VideoMetadata::VideoMetadata(
       endTime(startTime - frameDuration + duration),
       codec(avcodec_get_name(videoStream->codecpar->codec_id)),
       hwAccel(hasHwAccel(codecContext)),
+      decoderName(getDecoderName(codecContext)),
       _empty(false) {}
 
 std::string VideoMetadata::resolutionAsString() const {

--- a/src/VideoMetadata.cc
+++ b/src/VideoMetadata.cc
@@ -22,6 +22,10 @@ int getBitrate(AVStream *videoStream) {
   return bitrate;
 }
 
+bool hasHwAccel(AVCodecContext *codecContext) {
+  return codecContext ? codecContext->hw_device_ctx != NULL : false;
+}
+
 vivictpp::time::Time getStartTime(AVStream *stream) {
   return stream->start_time == AV_NOPTS_VALUE ? 0 :
     av_rescale_q(stream->start_time, stream->time_base, vivictpp::time::TIME_BASE_Q);
@@ -36,7 +40,8 @@ VideoMetadata::VideoMetadata(
     std::string source,
     AVFormatContext *formatContext,
     AVStream *videoStream,
-    FilteredVideoMetadata filteredVideoMetadata)
+    FilteredVideoMetadata filteredVideoMetadata,
+    AVCodecContext *codecContext)
     : source(source),
       //   pixelFormat(std::string(av_get_pix_fmt_name(codecContext->pix_fmt))),
       streamIndex(videoStream->index),
@@ -51,6 +56,7 @@ VideoMetadata::VideoMetadata(
       duration(formatContext->duration), // allready in av_time_base
       endTime(startTime - frameDuration + duration),
       codec(avcodec_get_name(videoStream->codecpar->codec_id)),
+      hwAccel(hasHwAccel(codecContext)),
       _empty(false) {}
 
 std::string VideoMetadata::resolutionAsString() const {

--- a/src/imgui/VideoMetadataDisplay.cc
+++ b/src/imgui/VideoMetadataDisplay.cc
@@ -23,6 +23,7 @@ void vivictpp::imgui::VideoMetadataDisplay::initMetadataText(const ui::DisplaySt
   metadataText.push_back({"duration", vivictpp::time::formatTime(metadata.duration)});
   metadataText.push_back({"start time", vivictpp::time::formatTime(metadata.startTime)});
   metadataText.push_back({"pixel format", metadata.pixelFormat});
+  metadataText.push_back({"Hardware accelerated", metadata.hwAccel ? "true" : "false"});
 }
 
 void vivictpp::imgui::VideoMetadataDisplay::initFrameMetadataText(const ui::DisplayState &displayState) {

--- a/src/imgui/VideoMetadataDisplay.cc
+++ b/src/imgui/VideoMetadataDisplay.cc
@@ -14,6 +14,8 @@ void vivictpp::imgui::VideoMetadataDisplay::initMetadataText(const ui::DisplaySt
   metadataText.clear();
   if (metadata.empty()) return;
   metadataText.push_back({"codec", metadata.codec});
+  metadataText.push_back({"decoder", metadata.decoderName});
+  metadataText.push_back({"hardware accelerated", metadata.hwAccel ? "true" : "false"});
   metadataText.push_back({"resolution", metadata.filteredResolution.toString()});
   if (metadata.filteredResolution != metadata.resolution) {
       metadataText.push_back({"orig resolution", metadata.resolution.toString()});
@@ -23,7 +25,6 @@ void vivictpp::imgui::VideoMetadataDisplay::initMetadataText(const ui::DisplaySt
   metadataText.push_back({"duration", vivictpp::time::formatTime(metadata.duration)});
   metadataText.push_back({"start time", vivictpp::time::formatTime(metadata.startTime)});
   metadataText.push_back({"pixel format", metadata.pixelFormat});
-  metadataText.push_back({"Hardware accelerated", metadata.hwAccel ? "true" : "false"});
 }
 
 void vivictpp::imgui::VideoMetadataDisplay::initFrameMetadataText(const ui::DisplayState &displayState) {

--- a/src/workers/PacketWorker.cc
+++ b/src/workers/PacketWorker.cc
@@ -42,7 +42,6 @@ void  vivictpp::workers::PacketWorker::initVideoMetadata() {
         auto codecContext = decoderWorker ? decoderWorker->getCodecContext() : NULL;
         VideoMetadata m =
             VideoMetadata(formatHandler.inputFile, formatHandler.getFormatContext(), videoStream, filteredVideoMetadata, codecContext);
-        logger->info("successfully created metadata instance");
         metadata.push_back(m);
     }
     {

--- a/src/workers/PacketWorker.cc
+++ b/src/workers/PacketWorker.cc
@@ -39,8 +39,10 @@ void  vivictpp::workers::PacketWorker::initVideoMetadata() {
     for (auto const &videoStream : formatHandler.getVideoStreams()) {
         std::shared_ptr<vivictpp::workers::DecoderWorker> decoderWorker = findDecoderWorkerForStream(decoderWorkers, videoStream);
         auto filteredVideoMetadata = decoderWorker ? decoderWorker->getFilteredVideoMetadata() : FilteredVideoMetadata();
+        auto codecContext = decoderWorker ? decoderWorker->getCodecContext() : NULL;
         VideoMetadata m =
-            VideoMetadata(formatHandler.inputFile, formatHandler.getFormatContext(), videoStream, filteredVideoMetadata);
+            VideoMetadata(formatHandler.inputFile, formatHandler.getFormatContext(), videoStream, filteredVideoMetadata, codecContext);
+        logger->info("successfully created metadata instance");
         metadata.push_back(m);
     }
     {


### PR DESCRIPTION
- Add `AVCodecContext` param to constructor for `VideoMetadata`. The data is provided by a packet worker.
   - Use this data to figure out if video is HW decoded, and if so, which device is used.
- Display HW acceleration status in metadata box.

closes #50 